### PR TITLE
Little cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,9 @@ func getSSTFromDir(in string) (result []string, err error) {
 		}
 		return nil
 	})
+	if err != nil {
+		return
+	}
 	if len(result) == 0 {
 		err = fmt.Errorf("%s has no sst files", in)
 	}


### PR DESCRIPTION
Добавлена обработка ошибок в getFilenames:

- пустая директория
- передан не  sst файл

Функция getFilenames разбита на более мелкие функции. Код приведен в более идиоматичный для Go вид. Например, объявление имен возвращаемых значениям позволяет избавиться от выражений вида `return nil nil`.